### PR TITLE
Disable caching of env-config.js

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -6,9 +6,9 @@ server {
         index  index.html;
         try_files $uri /index.html;                 
 
-	location = /config/env-config.js {
-		add_header Cache-Control "no-store";
-	}
+        location = /config/env-config.js {
+            add_header Cache-Control "no-store";
+        }
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,10 @@ server {
         root   /usr/share/nginx/html;
         index  index.html;
         try_files $uri /index.html;                 
+
+	location = /config/env-config.js {
+		add_header Cache-Control "no-store";
+	}
     }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
### What
Add cache control no-store to env-config.js.

### Why
The file does not have its name randomized like other JavaScript files
in the project and so it gets cached by CDNs and browsers. The name is
fixed in place so that it can be injected as the point of configuration.
Making it serve with a cache control value of no-store will prevent
caching at any CDN or browser.