### PR TITLE
Rename components to prepare for email verification

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppConfig } from "types.d/AppConfig";
 import { Page } from "types.d/Page";
 import { State } from "types.d/State";
-import { SendVerificationCode } from "components/SendVerificationCode";
-import { RequestVerificationCode } from "components/RequestVerificationCode";
+import { ConfirmVerification } from "components/ConfirmVerification";
+import { SendVerification } from "components/SendVerification";
 import { initApp } from "ducks/app";
 
 interface AppProps {
@@ -25,12 +25,12 @@ export function App({ config }: AppProps) {
   useEffect(() => {
     if (appDidLoad) {
       switch (currentPage) {
-        case Page.requestVerificationCode:
-          setComponent(<RequestVerificationCode />);
+        case Page.confirmVerification:
+          setComponent(<ConfirmVerification />);
           break;
 
         default:
-          setComponent(<SendVerificationCode />);
+          setComponent(<SendVerification />);
       }
     }
   }, [appDidLoad, currentPage]);

--- a/src/components/ConfirmVerification.tsx
+++ b/src/components/ConfirmVerification.tsx
@@ -9,7 +9,7 @@ import { useStatus } from "hooks/useStatus";
 import { CONFIRM_VERIFICATION_CODE } from "ducks/firebase";
 import { setPage } from "ducks/page";
 
-export function RequestVerificationCode() {
+export function ConfirmVerification() {
   const dispatch = useDispatch();
   const [verificationCode, setVerificationCode] = useState("");
   const { verificationId, idToken } = useSelector((state: State) => state);
@@ -35,7 +35,7 @@ export function RequestVerificationCode() {
   }, [status.hasLoaded, status.isSuccess, idToken]);
 
   const handleResend = () => {
-    dispatch(setPage(Page.sendVerificationCode));
+    dispatch(setPage(Page.sendVerification));
   };
 
   if (status.isSuccess) {

--- a/src/components/SendVerification.tsx
+++ b/src/components/SendVerification.tsx
@@ -11,7 +11,7 @@ import { State } from "types.d/State";
 
 const DELAY = 3000;
 
-export function SendVerificationCode() {
+export function SendVerification() {
   const dispatch = useDispatch();
   const status = useStatus(SEND_VERIFICATION_CODE);
   const [isLoading, setIsLoading] = useState(true);
@@ -35,7 +35,7 @@ export function SendVerificationCode() {
 
   useEffect(() => {
     if (verificationId) {
-      dispatch(setPage(Page.requestVerificationCode));
+      dispatch(setPage(Page.confirmVerification));
     }
   }, [verificationId, dispatch]);
 

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -11,7 +11,7 @@ import { reducer as statusReducer } from "./status";
 const initialState: State = {
   appDidLoad: false,
   phoneNumber: "",
-  currentPage: Page.sendVerificationCode,
+  currentPage: Page.sendVerification,
   statuses: {},
 } as State;
 

--- a/src/types.d/Page.ts
+++ b/src/types.d/Page.ts
@@ -1,4 +1,4 @@
 export enum Page {
-  requestVerificationCode = "requestVerificationCode",
-  sendVerificationCode = "sendVerificationCode",
+  confirmVerification = "confirmVerification",
+  sendVerification = "sendVerification",
 }


### PR DESCRIPTION
Wanted something more generic here, since we will be supporting `sendVerificationCode` and `sendVerificationEmail`.