### PR TITLE
Send email sign-in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ dev tools:
 main({ phoneNumber: "+15551112222" });
 ```
 
+or
+
+```js
+main({
+  email: "jordyn@dispostable.com",
+  // Vibrant needs to pass referrerId in, since it changes depending on the env
+  referrerId: "io.sunship.app",
+});
+```
+
 ## Building production files
 
 1. Run `yarn build`.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ or
 ```js
 main({
   email: "jordyn@dispostable.com",
-  // Vibrant needs to pass referrerId in, since it changes depending on the env
-  referrerId: "io.sunship.app",
+  // Vibrant needs to pass in dynamicLinkSettings, they change depending on the env
+  dynamicLinkSettings: {
+    referrerId: "io.sunship.app",
+    domain: "pasapesos.page.link",
+    path: "auth-email",
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ or
 
 ```js
 main({
-  email: "jordyn@dispostable.com",
-  // Vibrant needs to pass in dynamicLinkSettings, they change depending on the env
+  email: "jordyn@example.com",
+  // Client needs to pass in dynamicLinkSettings, they change depending on the env
   dynamicLinkSettings: {
     referrerId: "io.sunship.app",
     domain: "pasapesos.page.link",

--- a/src/components/SendVerification.tsx
+++ b/src/components/SendVerification.tsx
@@ -21,7 +21,7 @@ export function SendVerification() {
     verificationId,
     phoneNumber,
     email,
-    referrerId,
+    dynamicLinkSettings,
   } = useSelector((state: State) => state);
 
   const handleSendVerificationCode = () => {
@@ -32,10 +32,10 @@ export function SendVerification() {
           dispatch,
         });
       }
-      if (email && referrerId) {
+      if (email && dynamicLinkSettings) {
         sendVerificationEmail({
           email,
-          referrerId,
+          dynamicLinkSettings,
           dispatch,
         });
       }
@@ -45,7 +45,7 @@ export function SendVerification() {
   useEffect(() => {
     handleSendVerificationCode();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appDidLoad, phoneNumber, email, referrerId, dispatch]);
+  }, [appDidLoad, phoneNumber, email, dispatch]);
 
   useEffect(() => {
     if (verificationId) {
@@ -81,7 +81,7 @@ export function SendVerification() {
           <button className="button" onClick={handleSendVerificationCode}>
             <span>
               {phoneNumber && <Trans>Send verification code</Trans>}
-              {email && referrerId && <Trans>Send verification email</Trans>}
+              {email && <Trans>Send verification email</Trans>}
             </span>
           </button>
         </p>

--- a/src/components/SendVerification.tsx
+++ b/src/components/SendVerification.tsx
@@ -5,6 +5,7 @@ import { Trans } from "@lingui/macro";
 import { SEND_VERIFICATION_CODE } from "ducks/firebase";
 import { setPage } from "ducks/page";
 import { sendVerificationCode } from "helpers/sendVerificationCode";
+import { sendVerificationEmail } from "helpers/sendVerificationEmail";
 import { useStatus } from "hooks/useStatus";
 import { Page } from "types.d/Page";
 import { State } from "types.d/State";
@@ -15,23 +16,36 @@ export function SendVerification() {
   const dispatch = useDispatch();
   const status = useStatus(SEND_VERIFICATION_CODE);
   const [isLoading, setIsLoading] = useState(true);
-  const { appDidLoad, verificationId, phoneNumber } = useSelector(
-    (state: State) => state,
-  );
+  const {
+    appDidLoad,
+    verificationId,
+    phoneNumber,
+    email,
+    referrerId,
+  } = useSelector((state: State) => state);
 
   const handleSendVerificationCode = () => {
     if (appDidLoad) {
-      sendVerificationCode({
-        phoneNumber,
-        dispatch,
-      });
+      if (phoneNumber) {
+        sendVerificationCode({
+          phoneNumber,
+          dispatch,
+        });
+      }
+      if (email && referrerId) {
+        sendVerificationEmail({
+          email,
+          referrerId,
+          dispatch,
+        });
+      }
     }
   };
 
   useEffect(() => {
     handleSendVerificationCode();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appDidLoad, phoneNumber, dispatch]);
+  }, [appDidLoad, phoneNumber, email, referrerId, dispatch]);
 
   useEffect(() => {
     if (verificationId) {
@@ -66,7 +80,8 @@ export function SendVerification() {
         <p className="text-center">
           <button className="button" onClick={handleSendVerificationCode}>
             <span>
-              <Trans>Send verification code</Trans>
+              {phoneNumber && <Trans>Send verification code</Trans>}
+              {email && referrerId && <Trans>Send verification email</Trans>}
             </span>
           </button>
         </p>

--- a/src/ducks/firebase.ts
+++ b/src/ducks/firebase.ts
@@ -1,14 +1,21 @@
 import { State } from "types.d/State";
 
-type Actions = SendVerificationCodeAction | ConfirmVerificationCodeAction;
+type Actions =
+  | SendVerificationCodeAction
+  | SendVerificationEmailAction
+  | ConfirmVerificationCodeAction;
 
 export const CONFIRM_VERIFICATION_CODE = "firebase/CONFIRM_VERIFICATION_CODE";
 export const SEND_VERIFICATION_CODE = "firebase/SEND_VERIFICATION_CODE";
+export const SEND_VERIFICATION_EMAIL = "firebase/SEND_VERIFICATION_EMAIL";
 
 export function reducer(state: State, action: Actions) {
   switch (action.type) {
     case SEND_VERIFICATION_CODE:
       return { ...state, ...action.payload };
+
+    case SEND_VERIFICATION_EMAIL:
+      return { ...state };
 
     case CONFIRM_VERIFICATION_CODE:
       return { ...state, ...action.payload };
@@ -32,6 +39,14 @@ export function sendVerificationCode(
   payload: SendVerificationCodePayload,
 ): SendVerificationCodeAction {
   return { type: SEND_VERIFICATION_CODE, payload };
+}
+
+interface SendVerificationEmailAction {
+  type: typeof SEND_VERIFICATION_EMAIL;
+}
+
+export function sendVerificationEmail(): SendVerificationEmailAction {
+  return { type: SEND_VERIFICATION_EMAIL };
 }
 
 interface ConfirmVerificationCodeAction {

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -11,6 +11,7 @@ import { reducer as statusReducer } from "./status";
 const initialState: State = {
   appDidLoad: false,
   phoneNumber: "",
+  email: "",
   currentPage: Page.sendVerification,
   statuses: {},
 } as State;

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -1,0 +1,42 @@
+import { Dispatch } from "redux";
+
+import {
+  SEND_VERIFICATION_EMAIL,
+  sendVerificationEmail as action,
+} from "ducks/firebase";
+import { buildStatus } from "helpers/buildStatus";
+import { StatusType } from "types.d/Status";
+
+interface SendVerificationEmailParams {
+  email: string;
+  referrerId: string;
+  dispatch: Dispatch;
+}
+
+export async function sendVerificationEmail({
+  email,
+  referrerId,
+  dispatch,
+}: SendVerificationEmailParams) {
+  const setStatus = buildStatus(SEND_VERIFICATION_EMAIL, dispatch);
+  setStatus(StatusType.loading);
+
+  const dynamicLinkSettings = {
+    android: { installApp: true, packageName: referrerId },
+    dynamicLinkDomain: "pasapesos.page.link",
+    handleCodeInApp: true,
+    iOS: { bundleId: referrerId },
+    url: "https://pasapesos.page.link/email-auth",
+  };
+
+  firebase
+    .auth()
+    .sendSignInLinkToEmail(email, dynamicLinkSettings)
+    .then(() => {
+      dispatch(action());
+      setStatus(StatusType.success);
+    })
+    .catch((error) => {
+      setStatus(StatusType.error, new Error(error));
+    });
+}

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -5,33 +5,35 @@ import {
   sendVerificationEmail as action,
 } from "ducks/firebase";
 import { buildStatus } from "helpers/buildStatus";
+import { DynamicLinkSettings } from "types.d/AppConfig";
 import { StatusType } from "types.d/Status";
 
 interface SendVerificationEmailParams {
   email: string;
-  referrerId: string;
+  dynamicLinkSettings: DynamicLinkSettings;
   dispatch: Dispatch;
 }
 
 export async function sendVerificationEmail({
   email,
-  referrerId,
+  dynamicLinkSettings,
   dispatch,
 }: SendVerificationEmailParams) {
   const setStatus = buildStatus(SEND_VERIFICATION_EMAIL, dispatch);
   setStatus(StatusType.loading);
 
-  const dynamicLinkSettings = {
+  const { referrerId, domain, path } = dynamicLinkSettings;
+  const dynamicLinkConfig = {
     android: { installApp: true, packageName: referrerId },
-    dynamicLinkDomain: "pasapesos.page.link",
+    domain: `${domain}`,
     handleCodeInApp: true,
     iOS: { bundleId: referrerId },
-    url: "https://pasapesos.page.link/email-auth",
+    url: `https://${domain}/${path}`,
   };
 
   firebase
     .auth()
-    .sendSignInLinkToEmail(email, dynamicLinkSettings)
+    .sendSignInLinkToEmail(email, dynamicLinkConfig)
     .then(() => {
       dispatch(action());
       setStatus(StatusType.success);

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -26,7 +26,7 @@ msgstr "Please fill out the captcha to proceed."
 msgid "Please provide a valid phone number."
 msgstr "Please provide a valid phone number."
 
-#: src/components/SendVerification.tsx:44
+#: src/components/SendVerification.tsx:54
 msgid "Please wait…"
 msgstr "Please wait…"
 
@@ -34,9 +34,13 @@ msgstr "Please wait…"
 msgid "Resend"
 msgstr "Resend"
 
-#: src/components/SendVerification.tsx:53
+#: src/components/SendVerification.tsx:63
 msgid "Send verification code"
 msgstr "Send verification code"
+
+#: src/components/SendVerification.tsx:64
+msgid "Send verification email"
+msgstr "Send verification email"
 
 #: src/helpers/getFirebaseError.ts:9
 msgid "The confirmation code you provided is invalid."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -31,7 +31,7 @@ msgstr "Por favor completa el captcha para proceder."
 msgid "Please provide a valid phone number."
 msgstr "Por favor provee un número de teléfono válido."
 
-#: src/components/SendVerification.tsx:44
+#: src/components/SendVerification.tsx:54
 msgid "Please wait…"
 msgstr "Por favor espera…"
 
@@ -39,9 +39,13 @@ msgstr "Por favor espera…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerification.tsx:53
+#: src/components/SendVerification.tsx:63
 msgid "Send verification code"
 msgstr "Enviar código de verificación"
+
+#: src/components/SendVerification.tsx:64
+msgid "Send verification email"
+msgstr ""
 
 #: src/helpers/getFirebaseError.ts:9
 msgid "The confirmation code you provided is invalid."

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -1,5 +1,7 @@
 export interface AppConfig {
   phoneNumber: string;
+  email: string;
+  referrerId: string;
   recaptchaVerifier: firebase.auth.RecaptchaVerifier;
   language: string;
 }

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -1,7 +1,13 @@
+export interface DynamicLinkSettings {
+  referrerId: string;
+  domain: string;
+  path: string;
+}
+
 export interface AppConfig {
   phoneNumber: string;
   email: string;
-  referrerId: string;
+  dynamicLinkSettings?: DynamicLinkSettings;
   recaptchaVerifier: firebase.auth.RecaptchaVerifier;
   language: string;
 }

--- a/src/types.d/State.ts
+++ b/src/types.d/State.ts
@@ -1,11 +1,12 @@
 import { FirebaseAppConfig } from "@firebase/app-types";
+import { DynamicLinkSettings } from "types.d/AppConfig";
 import { Page } from "types.d/Page";
 import { Status } from "types.d/Status";
 
 export interface State {
   phoneNumber: string;
   email: string;
-  referrerId: string;
+  dynamicLinkSettings?: DynamicLinkSettings;
   currentPage: Page;
   appDidLoad: boolean;
   statuses: { [key: string]: Status };

--- a/src/types.d/State.ts
+++ b/src/types.d/State.ts
@@ -4,6 +4,8 @@ import { Status } from "types.d/Status";
 
 export interface State {
   phoneNumber: string;
+  email: string;
+  referrerId: string;
   currentPage: Page;
   appDidLoad: boolean;
   statuses: { [key: string]: Status };


### PR DESCRIPTION
If you call main like this:
```js
main({
  email: "jordyn@dispostable.com",
  dynamicLinkSettings: {
    referrerId: "io.sunship.app",
    domain: "pasapesos.page.link",
    path: "auth-email",
  },
});
```
we will send an email with a link to sign in. Clicking the link will open Vibrant.

I will be updating Vibrant to intercept the link and pass it back into the recovery server screen. The recovery server will use it to finish the sign in process.