### PR TITLE
Clean up types

### DIFF
--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -10,8 +10,6 @@ import { reducer as statusReducer } from "./status";
 
 const initialState: State = {
   appDidLoad: false,
-  phoneNumber: "",
-  email: "",
   currentPage: Page.sendVerification,
   statuses: {},
 } as State;

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -5,9 +5,13 @@ export interface DynamicLinkSettings {
 }
 
 export interface AppConfig {
-  phoneNumber: string;
-  email: string;
+  // required for 'auth with phone'
+  phoneNumber?: string;
+
+  // required for 'auth with email'
+  email?: string;
   dynamicLinkSettings?: DynamicLinkSettings;
+
   recaptchaVerifier: firebase.auth.RecaptchaVerifier;
   language: string;
 }

--- a/src/types.d/State.ts
+++ b/src/types.d/State.ts
@@ -4,9 +4,11 @@ import { Page } from "types.d/Page";
 import { Status } from "types.d/Status";
 
 export interface State {
-  phoneNumber: string;
-  email: string;
+  phoneNumber?: string;
+
+  email?: string;
   dynamicLinkSettings?: DynamicLinkSettings;
+
   currentPage: Page;
   appDidLoad: boolean;
   statuses: { [key: string]: Status };


### PR DESCRIPTION
`phoneNumber` and `email` are optional now, but I also wanted to group them to indicate which args you need if you're trying to 'auth with phone' or 'auth with email'.