### PR TITLE
Add Landing page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,7 +6,9 @@ import { Page } from "types.d/Page";
 import { State } from "types.d/State";
 import { ConfirmVerificationCode } from "components/ConfirmVerificationCode";
 import { ConfirmVerificationEmail } from "components/ConfirmVerificationEmail";
-import { SendVerification } from "components/SendVerification";
+import { Landing } from "components/Landing";
+import { SendVerificationCode } from "components/SendVerificationCode";
+import { SendVerificationEmail } from "components/SendVerificationEmail";
 import { initApp } from "ducks/app";
 
 interface AppProps {
@@ -26,6 +28,14 @@ export function App({ config }: AppProps) {
   useEffect(() => {
     if (appDidLoad) {
       switch (currentPage) {
+        case Page.sendVerificationCode:
+          setComponent(<SendVerificationCode />);
+          break;
+
+        case Page.sendVerificationEmail:
+          setComponent(<SendVerificationEmail />);
+          break;
+
         case Page.confirmVerificationCode:
           setComponent(<ConfirmVerificationCode />);
           break;
@@ -35,7 +45,7 @@ export function App({ config }: AppProps) {
           break;
 
         default:
-          setComponent(<SendVerification />);
+          setComponent(<Landing />);
       }
     }
   }, [appDidLoad, currentPage]);

--- a/src/components/ConfirmVerificationCode.tsx
+++ b/src/components/ConfirmVerificationCode.tsx
@@ -35,7 +35,7 @@ export function ConfirmVerificationCode() {
   }, [status.hasLoaded, status.isSuccess, idToken]);
 
   const handleResend = () => {
-    dispatch(setPage(Page.sendVerification));
+    dispatch(setPage(Page.sendVerificationCode));
   };
 
   if (status.isSuccess) {

--- a/src/components/ConfirmVerificationEmail.tsx
+++ b/src/components/ConfirmVerificationEmail.tsx
@@ -11,7 +11,7 @@ export function ConfirmVerificationEmail() {
   const { email } = useSelector((state: State) => state);
 
   const handleResend = () => {
-    dispatch(setPage(Page.sendVerification));
+    dispatch(setPage(Page.sendVerificationEmail));
   };
 
   return (

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { setPage } from "ducks/page";
+import { Page } from "types.d/Page";
+import { State } from "types.d/State";
+
+export function Landing() {
+  const dispatch = useDispatch();
+  const { appDidLoad, phoneNumber, email, dynamicLinkSettings } = useSelector(
+    (state: State) => state,
+  );
+
+  useEffect(() => {
+    if (appDidLoad) {
+      // auth with phone
+      if (phoneNumber) {
+        dispatch(setPage(Page.sendVerificationCode));
+      }
+      // auth with email
+      if (email && dynamicLinkSettings) {
+        dispatch(setPage(Page.sendVerificationEmail));
+      }
+      // confirm auth with email
+      // TODO - if (email && signInLink) { dispatch(setPage(Page.confirmVerificationEmail)); }
+    }
+  }, [appDidLoad, phoneNumber, email, dynamicLinkSettings, dispatch]);
+
+  return <div className="panel"></div>;
+}

--- a/src/components/SendVerificationCode.tsx
+++ b/src/components/SendVerificationCode.tsx
@@ -55,7 +55,11 @@ export function SendVerificationCode() {
         </div>
       )}
 
-      {sendCodeStatus.error && <p>Error: {sendCodeStatus.error.message}</p>}
+      {sendCodeStatus.error && (
+        <p>
+          <Trans>Error: {sendCodeStatus.error.message}</Trans>
+        </p>
+      )}
 
       {!isLoading && !sendCodeStatus.error && (
         <p className="text-center">

--- a/src/components/SendVerificationCode.tsx
+++ b/src/components/SendVerificationCode.tsx
@@ -2,52 +2,37 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Trans } from "@lingui/macro";
 
-import {
-  SEND_VERIFICATION_CODE,
-  SEND_VERIFICATION_EMAIL,
-} from "ducks/firebase";
+import { SEND_VERIFICATION_CODE } from "ducks/firebase";
 import { setPage } from "ducks/page";
 import { sendVerificationCode } from "helpers/sendVerificationCode";
-import { sendVerificationEmail } from "helpers/sendVerificationEmail";
 import { useStatus } from "hooks/useStatus";
 import { Page } from "types.d/Page";
 import { State } from "types.d/State";
 
 const DELAY = 3000;
 
-export function SendVerification() {
+export function SendVerificationCode() {
   const dispatch = useDispatch();
   const sendCodeStatus = useStatus(SEND_VERIFICATION_CODE);
-  const sendEmailStatus = useStatus(SEND_VERIFICATION_EMAIL);
   const [isLoading, setIsLoading] = useState(true);
-  const { appDidLoad, phoneNumber, email, dynamicLinkSettings } = useSelector(
-    (state: State) => state,
-  );
+  const { phoneNumber } = useSelector((state: State) => state);
 
   const handleSendVerification = () => {
-    if (appDidLoad) {
-      if (phoneNumber) {
-        sendVerificationCode({ phoneNumber, dispatch });
-      }
-      if (email && dynamicLinkSettings) {
-        sendVerificationEmail({ email, dynamicLinkSettings, dispatch });
-      }
+    if (phoneNumber) {
+      sendVerificationCode({ phoneNumber, dispatch });
     }
   };
 
   useEffect(() => {
     handleSendVerification();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appDidLoad, dispatch]);
+  }, [dispatch]);
 
   useEffect(() => {
     if (sendCodeStatus.isSuccess) {
       dispatch(setPage(Page.confirmVerificationCode));
     }
-    if (sendEmailStatus.isSuccess) {
-      dispatch(setPage(Page.confirmVerificationEmail));
-    }
-  }, [sendCodeStatus.isSuccess, sendEmailStatus.isSuccess, dispatch]);
+  }, [sendCodeStatus.isSuccess, dispatch]);
 
   // We automatically trigger the recaptcha verification. To avoid flashing the
   // "Send verification code" button, we display the button when DELAY has
@@ -71,14 +56,12 @@ export function SendVerification() {
       )}
 
       {sendCodeStatus.error && <p>Error: {sendCodeStatus.error.message}</p>}
-      {sendEmailStatus.error && <p>Error: {sendEmailStatus.error.message}</p>}
 
-      {!isLoading && !sendCodeStatus.error && !sendEmailStatus.error && (
+      {!isLoading && !sendCodeStatus.error && (
         <p className="text-center">
           <button className="button" onClick={handleSendVerification}>
             <span>
-              {phoneNumber && <Trans>Send verification code</Trans>}
-              {email && <Trans>Send verification email</Trans>}
+              <Trans>Send verification code</Trans>
             </span>
           </button>
         </p>

--- a/src/components/SendVerificationEmail.tsx
+++ b/src/components/SendVerificationEmail.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Trans } from "@lingui/macro";
+
+import { SEND_VERIFICATION_EMAIL } from "ducks/firebase";
+import { setPage } from "ducks/page";
+import { sendVerificationEmail } from "helpers/sendVerificationEmail";
+import { useStatus } from "hooks/useStatus";
+import { Page } from "types.d/Page";
+import { State } from "types.d/State";
+
+export function SendVerificationEmail() {
+  const dispatch = useDispatch();
+  const sendEmailStatus = useStatus(SEND_VERIFICATION_EMAIL);
+  const { email, dynamicLinkSettings } = useSelector((state: State) => state);
+
+  useEffect(() => {
+    if (email && dynamicLinkSettings) {
+      sendVerificationEmail({ email, dynamicLinkSettings, dispatch });
+    }
+  }, [email, dynamicLinkSettings, dispatch]);
+
+  useEffect(() => {
+    if (sendEmailStatus.isSuccess) {
+      dispatch(setPage(Page.confirmVerificationEmail));
+    }
+  }, [sendEmailStatus.isSuccess, dispatch]);
+
+  return (
+    <div className="panel">
+      <div className="text-center text-large">
+        <p>
+          <Trans>Please wait…</Trans>
+        </p>
+      </div>
+
+      {sendEmailStatus.error && <p>Error: {sendEmailStatus.error.message}</p>}
+    </div>
+  );
+}

--- a/src/components/SendVerificationEmail.tsx
+++ b/src/components/SendVerificationEmail.tsx
@@ -34,7 +34,11 @@ export function SendVerificationEmail() {
         </p>
       </div>
 
-      {sendEmailStatus.error && <p>Error: {sendEmailStatus.error.message}</p>}
+      {sendEmailStatus.error && (
+        <p>
+          <Trans>Error: {sendEmailStatus.error.message}</Trans>
+        </p>
+      )}
     </div>
   );
 }

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -10,7 +10,7 @@ import { reducer as statusReducer } from "./status";
 
 const initialState: State = {
   appDidLoad: false,
-  currentPage: Page.sendVerification,
+  currentPage: Page.landing,
   statuses: {},
 } as State;
 

--- a/src/helpers/sendVerificationCode.ts
+++ b/src/helpers/sendVerificationCode.ts
@@ -5,6 +5,7 @@ import {
   sendVerificationCode as action,
 } from "ducks/firebase";
 import { buildStatus } from "helpers/buildStatus";
+import { getFirebaseError } from "helpers/getFirebaseError";
 import { StatusType } from "types.d/Status";
 
 interface SendVerificationCodeParams {
@@ -45,37 +46,7 @@ export async function sendVerificationCode({
     dispatch(action({ provider, verificationId }));
     setStatus(StatusType.success);
   } catch (error) {
-    let message = error.message;
-
-    if (error.code) {
-      switch (error.code) {
-        case "auth/missing-verification-code":
-        case "auth/invalid-verification-code":
-          message = "The confirmation code you provided is invalid.";
-          break;
-
-        case "auth/missing-phone-number":
-        case "auth/invalid-phone-number":
-          message = "Please provide a valid phone number.";
-          break;
-
-        case "auth/too-many-requests":
-          message =
-            "You’ve tried to do that too many times. Please wait a while and try again!";
-          break;
-
-        case "auth/popup-closed-by-user":
-          message = "Please fill out the captcha to proceed.";
-          break;
-
-        default:
-          try {
-            message = JSON.parse(message).error.message;
-          } catch (anotherError) {
-            message = error.toString();
-          }
-      }
-    }
+    const message = getFirebaseError(error);
 
     setStatus(StatusType.error, new Error(message));
   }

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -5,6 +5,7 @@ import {
   sendVerificationEmail as action,
 } from "ducks/firebase";
 import { buildStatus } from "helpers/buildStatus";
+import { getFirebaseError } from "helpers/getFirebaseError";
 import { DynamicLinkSettings } from "types.d/AppConfig";
 import { StatusType } from "types.d/Status";
 
@@ -39,6 +40,8 @@ export async function sendVerificationEmail({
       setStatus(StatusType.success);
     })
     .catch((error) => {
-      setStatus(StatusType.error, new Error(error));
+      const message = getFirebaseError(error);
+
+      setStatus(StatusType.error, new Error(message));
     });
 }

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/SendVerificationCode.tsx:46
+#: src/components/SendVerificationEmail.tsx:31
+msgid "Error: {0}"
+msgstr "Error: {0}"
+
 #: src/components/ConfirmVerificationEmail.tsx:15
 #~ msgid "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
 #~ msgstr "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
@@ -48,7 +53,7 @@ msgstr "Please wait…"
 msgid "Resend"
 msgstr "Resend"
 
-#: src/components/SendVerificationCode.tsx:50
+#: src/components/SendVerificationCode.tsx:52
 msgid "Send verification code"
 msgstr "Send verification code"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -38,7 +38,8 @@ msgstr "Please fill out the captcha to proceed."
 msgid "Please provide a valid phone number."
 msgstr "Please provide a valid phone number."
 
-#: src/components/SendVerification.tsx:51
+#: src/components/SendVerificationCode.tsx:41
+#: src/components/SendVerificationEmail.tsx:26
 msgid "Please wait…"
 msgstr "Please wait…"
 
@@ -47,13 +48,13 @@ msgstr "Please wait…"
 msgid "Resend"
 msgstr "Resend"
 
-#: src/components/SendVerification.tsx:61
+#: src/components/SendVerificationCode.tsx:50
 msgid "Send verification code"
 msgstr "Send verification code"
 
-#: src/components/SendVerification.tsx:62
-msgid "Send verification email"
-msgstr "Send verification email"
+#: src/components/SendVerificationEmail.tsx:51
+#~ msgid "Send verification email"
+#~ msgstr "Send verification email"
 
 #: src/helpers/getFirebaseError.ts:9
 msgid "The confirmation code you provided is invalid."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -43,7 +43,8 @@ msgstr "Por favor completa el captcha para proceder."
 msgid "Please provide a valid phone number."
 msgstr "Por favor provee un número de teléfono válido."
 
-#: src/components/SendVerification.tsx:51
+#: src/components/SendVerificationCode.tsx:41
+#: src/components/SendVerificationEmail.tsx:26
 msgid "Please wait…"
 msgstr "Por favor espera…"
 
@@ -52,13 +53,13 @@ msgstr "Por favor espera…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerification.tsx:61
+#: src/components/SendVerificationCode.tsx:50
 msgid "Send verification code"
 msgstr "Enviar código de verificación"
 
-#: src/components/SendVerification.tsx:62
-msgid "Send verification email"
-msgstr ""
+#: src/components/SendVerificationEmail.tsx:51
+#~ msgid "Send verification email"
+#~ msgstr ""
 
 #: src/helpers/getFirebaseError.ts:9
 msgid "The confirmation code you provided is invalid."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,6 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 64\n"
 
+#: src/components/SendVerificationCode.tsx:46
+#: src/components/SendVerificationEmail.tsx:31
+msgid "Error: {0}"
+msgstr ""
+
 #: src/components/ConfirmVerificationEmail.tsx:15
 #~ msgid "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
 #~ msgstr ""
@@ -53,7 +58,7 @@ msgstr "Por favor espera…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerificationCode.tsx:50
+#: src/components/SendVerificationCode.tsx:52
 msgid "Send verification code"
 msgstr "Enviar código de verificación"
 

--- a/src/types.d/Page.ts
+++ b/src/types.d/Page.ts
@@ -1,5 +1,7 @@
 export enum Page {
   confirmVerificationCode = "confirmVerificationCode",
   confirmVerificationEmail = "confirmVerificationEmail",
-  sendVerification = "sendVerification",
+  landing = "landing",
+  sendVerificationCode = "sendVerificationCode",
+  sendVerificationEmail = "sendVerificationEmail",
 }


### PR DESCRIPTION
Instead of jumping straight to `SendVerification`, the app will start at `Landing`. `Landing` looks at the params and decides whether you're trying to 'auth with phone', 'auth with email', or (upcoming) 'confirm auth with email'. 

[Upcoming PR] Confirming email will require another call to `main()`, since we will need to pass the link from the user's email into this app. So instead of going from send -> confirm, as the phone flow does, both actions will go through `Landing`.

I also split `SendVerification` into `SendVerificationCode` and `SendVerificationEmail`. There were a lot of conditionals, plus emal doesn't require a recaptcha.