### PR TITLE
Rename ConfirmVerificationEmail to SentVerificationEmail

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ import { AppConfig } from "types.d/AppConfig";
 import { Page } from "types.d/Page";
 import { State } from "types.d/State";
 import { ConfirmVerificationCode } from "components/ConfirmVerificationCode";
-import { ConfirmVerificationEmail } from "components/ConfirmVerificationEmail";
+import { SentVerificationEmail } from "components/SentVerificationEmail";
 import { Landing } from "components/Landing";
 import { SendVerificationCode } from "components/SendVerificationCode";
 import { SendVerificationEmail } from "components/SendVerificationEmail";
@@ -32,16 +32,16 @@ export function App({ config }: AppProps) {
           setComponent(<SendVerificationCode />);
           break;
 
-        case Page.sendVerificationEmail:
-          setComponent(<SendVerificationEmail />);
-          break;
-
         case Page.confirmVerificationCode:
           setComponent(<ConfirmVerificationCode />);
           break;
 
-        case Page.confirmVerificationEmail:
-          setComponent(<ConfirmVerificationEmail />);
+        case Page.sendVerificationEmail:
+          setComponent(<SendVerificationEmail />);
+          break;
+
+        case Page.sentVerificationEmail:
+          setComponent(<SentVerificationEmail />);
           break;
 
         default:

--- a/src/components/SendVerificationEmail.tsx
+++ b/src/components/SendVerificationEmail.tsx
@@ -22,7 +22,7 @@ export function SendVerificationEmail() {
 
   useEffect(() => {
     if (sendEmailStatus.isSuccess) {
-      dispatch(setPage(Page.confirmVerificationEmail));
+      dispatch(setPage(Page.sentVerificationEmail));
     }
   }, [sendEmailStatus.isSuccess, dispatch]);
 

--- a/src/components/SentVerificationEmail.tsx
+++ b/src/components/SentVerificationEmail.tsx
@@ -6,7 +6,7 @@ import { State } from "types.d/State";
 import { Page } from "types.d/Page";
 import { setPage } from "ducks/page";
 
-export function ConfirmVerificationEmail() {
+export function SentVerificationEmail() {
   const dispatch = useDispatch();
   const { email } = useSelector((state: State) => state);
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -22,7 +22,7 @@ msgstr "Error: {0}"
 #~ msgid "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
 #~ msgstr "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
 
-#: src/components/ConfirmVerificationEmail.tsx:15
+#: src/components/SentVerificationEmail.tsx:15
 msgid "If the below email address is associated with an account, you will receive a verification email."
 msgstr "If the below email address is associated with an account, you will receive a verification email."
 
@@ -31,7 +31,7 @@ msgstr "If the below email address is associated with an account, you will recei
 msgid "Oops! Please try again in a few minutes. (error code: {0})"
 msgstr "Oops! Please try again in a few minutes. (error code: {0})"
 
-#: src/components/ConfirmVerificationEmail.tsx:22
+#: src/components/SentVerificationEmail.tsx:22
 msgid "Please check your email and click the verification link in the email message to proceed."
 msgstr "Please check your email and click the verification link in the email message to proceed."
 
@@ -49,7 +49,7 @@ msgid "Please wait…"
 msgstr "Please wait…"
 
 #: src/components/ConfirmVerificationCode.tsx:54
-#: src/components/ConfirmVerificationEmail.tsx:32
+#: src/components/SentVerificationEmail.tsx:32
 msgid "Resend"
 msgstr "Resend"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -27,7 +27,7 @@ msgstr ""
 #~ msgid "If the below email address is associated with an account, you will receive a verification email blahhhhfjhsdkhfdshfksdfd."
 #~ msgstr ""
 
-#: src/components/ConfirmVerificationEmail.tsx:15
+#: src/components/SentVerificationEmail.tsx:15
 msgid "If the below email address is associated with an account, you will receive a verification email."
 msgstr ""
 
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Oops! Please try again in a few minutes. (error code: {0})"
 msgstr "¡Ups! Por favor intenta nuevamente en unos minutos. (código de error: {0})"
 
-#: src/components/ConfirmVerificationEmail.tsx:22
+#: src/components/SentVerificationEmail.tsx:22
 msgid "Please check your email and click the verification link in the email message to proceed."
 msgstr ""
 
@@ -54,7 +54,7 @@ msgid "Please wait…"
 msgstr "Por favor espera…"
 
 #: src/components/ConfirmVerificationCode.tsx:54
-#: src/components/ConfirmVerificationEmail.tsx:32
+#: src/components/SentVerificationEmail.tsx:32
 msgid "Resend"
 msgstr "Reenviar"
 

--- a/src/types.d/Page.ts
+++ b/src/types.d/Page.ts
@@ -1,7 +1,7 @@
 export enum Page {
   confirmVerificationCode = "confirmVerificationCode",
-  confirmVerificationEmail = "confirmVerificationEmail",
   landing = "landing",
   sendVerificationCode = "sendVerificationCode",
   sendVerificationEmail = "sendVerificationEmail",
+  sentVerificationEmail = "sentVerificationEmail",
 }


### PR DESCRIPTION
This page is only indicating that we sent you an email. I will be adding another page in the next PR which will be called ConfirmVerificationEmail, which is where we will do the actual confirming.