### PR TITLE
Complete email sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,27 @@ Run the following script in your browser console:
 ```js
 main({
   email: "jordyn@example.com",
-  // Client needs to pass in dynamicLinkSettings, they change depending on the env and are used by Firebase to generate a sign-in link
+  // Client needs to pass in dynamicLinkSettings, they change depending on
+  // the env and are used by Firebase to generate a sign-in link
   dynamicLinkSettings: {
     domain: "pasapesos.page.link", // dynamic link domain
     path: "auth-email", // dynamic link path
-    referrerId: "io.sunship.app", // app the dynamic link will send you to
+    referrerId: "io.example.app", // app the dynamic link will send you to
   },
 });
 ```
 
-A link will be sent to that email.
+A link will be sent to that email. To complete sign-in, refresh the browser and
+run:
+
+```js
+main({
+  email: "jordyn@example.com",
+  // link from email
+  signInLink:
+    "https://example.firebaseapp.com/__/auth/action?apiKey=[apiKey]&mode=signIn&oobCode=[oobCode]&continueUrl=https://sunship.page.link/email-auth&lang=en",
+});
+```
 
 ## Building production files
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,7 @@ import { AppConfig } from "types.d/AppConfig";
 import { Page } from "types.d/Page";
 import { State } from "types.d/State";
 import { ConfirmVerificationCode } from "components/ConfirmVerificationCode";
+import { ConfirmVerificationEmail } from "components/ConfirmVerificationEmail";
 import { SentVerificationEmail } from "components/SentVerificationEmail";
 import { Landing } from "components/Landing";
 import { SendVerificationCode } from "components/SendVerificationCode";
@@ -42,6 +43,10 @@ export function App({ config }: AppProps) {
 
         case Page.sentVerificationEmail:
           setComponent(<SentVerificationEmail />);
+          break;
+
+        case Page.confirmVerificationEmail:
+          setComponent(<ConfirmVerificationEmail />);
           break;
 
         default:

--- a/src/components/ConfirmVerificationEmail.tsx
+++ b/src/components/ConfirmVerificationEmail.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Trans } from "@lingui/macro";
+
+import { State } from "types.d/State";
+import { confirmVerificationEmail } from "helpers/confirmVerificationEmail";
+import { useStatus } from "hooks/useStatus";
+import { CONFIRM_VERIFICATION_EMAIL } from "ducks/firebase";
+
+export function ConfirmVerificationEmail() {
+  const dispatch = useDispatch();
+  const { signInLink, email, idToken } = useSelector((state: State) => state);
+  const confirmEmailStatus = useStatus(CONFIRM_VERIFICATION_EMAIL);
+
+  useEffect(() => {
+    if (signInLink && email) {
+      confirmVerificationEmail({
+        verificationUrl: signInLink,
+        verificationEmail: email,
+        dispatch,
+      });
+    }
+  }, [signInLink, email, dispatch]);
+
+  useEffect(() => {
+    if (confirmEmailStatus.isSuccess) {
+      window.postMessage(
+        JSON.stringify({ type: "idToken", idToken }),
+        window.location.origin,
+      );
+    }
+  }, [confirmEmailStatus.isSuccess, idToken]);
+
+  if (confirmEmailStatus.isSuccess) {
+    return (
+      <div className="panel">
+        <p className="text-center text-large">
+          <Trans>You’ve been verified! Please wait.</Trans>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <div className="text-center text-large">
+        <p>
+          <Trans>Please wait…</Trans>
+        </p>
+      </div>
+
+      {confirmEmailStatus.error && (
+        <p>
+          <Trans>Error: {confirmEmailStatus.error.message}</Trans>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -7,9 +7,13 @@ import { State } from "types.d/State";
 
 export function Landing() {
   const dispatch = useDispatch();
-  const { appDidLoad, phoneNumber, email, dynamicLinkSettings } = useSelector(
-    (state: State) => state,
-  );
+  const {
+    appDidLoad,
+    phoneNumber,
+    email,
+    dynamicLinkSettings,
+    signInLink,
+  } = useSelector((state: State) => state);
 
   useEffect(() => {
     if (appDidLoad) {
@@ -22,9 +26,18 @@ export function Landing() {
         dispatch(setPage(Page.sendVerificationEmail));
       }
       // confirm auth with email
-      // TODO - if (email && signInLink) { dispatch(setPage(Page.confirmVerificationEmail)); }
+      if (email && signInLink) {
+        dispatch(setPage(Page.confirmVerificationEmail));
+      }
     }
-  }, [appDidLoad, phoneNumber, email, dynamicLinkSettings, dispatch]);
+  }, [
+    appDidLoad,
+    phoneNumber,
+    email,
+    dynamicLinkSettings,
+    signInLink,
+    dispatch,
+  ]);
 
   return <div className="panel"></div>;
 }

--- a/src/ducks/firebase.ts
+++ b/src/ducks/firebase.ts
@@ -3,7 +3,8 @@ import { State } from "types.d/State";
 type Actions =
   | SendVerificationCodeAction
   | SendVerificationEmailAction
-  | ConfirmVerificationCodeAction;
+  | ConfirmVerificationCodeAction
+  | ConfirmVerificationEmailAction;
 
 export const SEND_VERIFICATION_CODE = "firebase/SEND_VERIFICATION_CODE";
 export const SEND_VERIFICATION_EMAIL = "firebase/SEND_VERIFICATION_EMAIL";
@@ -21,10 +22,15 @@ export function reducer(state: State, action: Actions) {
     case CONFIRM_VERIFICATION_CODE:
       return { ...state, ...action.payload };
 
+    case CONFIRM_VERIFICATION_EMAIL:
+      return { ...state, ...action.payload };
+
     default:
       return state;
   }
 }
+
+// Send verification code
 
 interface SendVerificationCodeAction {
   type: typeof SEND_VERIFICATION_CODE;
@@ -42,6 +48,8 @@ export function sendVerificationCode(
   return { type: SEND_VERIFICATION_CODE, payload };
 }
 
+// Send verification email
+
 interface SendVerificationEmailAction {
   type: typeof SEND_VERIFICATION_EMAIL;
 }
@@ -49,6 +57,8 @@ interface SendVerificationEmailAction {
 export function sendVerificationEmail(): SendVerificationEmailAction {
   return { type: SEND_VERIFICATION_EMAIL };
 }
+
+// Confirm verification code
 
 interface ConfirmVerificationCodeAction {
   type: typeof CONFIRM_VERIFICATION_CODE;
@@ -63,4 +73,21 @@ export function confirmVerificationCode(
   payload: ConfirmVerificationCodePayload,
 ): ConfirmVerificationCodeAction {
   return { type: CONFIRM_VERIFICATION_CODE, payload };
+}
+
+// Confirm verification email
+
+interface ConfirmVerificationEmailAction {
+  type: typeof CONFIRM_VERIFICATION_EMAIL;
+  payload: ConfirmVerificationEmailPayload;
+}
+
+interface ConfirmVerificationEmailPayload {
+  idToken: string;
+}
+
+export function confirmVerificationEmail(
+  payload: ConfirmVerificationEmailPayload,
+): ConfirmVerificationEmailAction {
+  return { type: CONFIRM_VERIFICATION_EMAIL, payload };
 }

--- a/src/helpers/confirmVerificationEmail.ts
+++ b/src/helpers/confirmVerificationEmail.ts
@@ -1,0 +1,38 @@
+import { Dispatch } from "redux";
+
+import {
+  confirmVerificationCode as action,
+  CONFIRM_VERIFICATION_EMAIL,
+} from "ducks/firebase";
+import { buildStatus } from "helpers/buildStatus";
+import { getFirebaseError } from "helpers/getFirebaseError";
+import { StatusType } from "types.d/Status";
+
+interface ConfirmVerificationEmailParams {
+  verificationUrl: string;
+  verificationEmail: string;
+  dispatch: Dispatch;
+}
+
+export async function confirmVerificationEmail({
+  verificationUrl,
+  verificationEmail,
+  dispatch,
+}: ConfirmVerificationEmailParams) {
+  const setStatus = buildStatus(CONFIRM_VERIFICATION_EMAIL, dispatch);
+  setStatus(StatusType.loading);
+
+  try {
+    const auth = await firebase
+      .auth()
+      .signInWithEmailLink(verificationEmail, verificationUrl);
+    const idToken = await auth.user!.getIdToken();
+
+    dispatch(action({ idToken }));
+    setStatus(StatusType.success);
+  } catch (error) {
+    const message = getFirebaseError(error);
+
+    setStatus(StatusType.error, new Error(message));
+  }
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/ConfirmVerificationEmail.tsx:40
 #: src/components/SendVerificationCode.tsx:46
 #: src/components/SendVerificationEmail.tsx:31
 msgid "Error: {0}"
@@ -43,6 +44,7 @@ msgstr "Please fill out the captcha to proceed."
 msgid "Please provide a valid phone number."
 msgstr "Please provide a valid phone number."
 
+#: src/components/ConfirmVerificationEmail.tsx:35
 #: src/components/SendVerificationCode.tsx:41
 #: src/components/SendVerificationEmail.tsx:26
 msgid "Please wait…"
@@ -78,6 +80,7 @@ msgid "We’ve sent you a verification code:"
 msgstr "We’ve sent you a verification code:"
 
 #: src/components/ConfirmVerificationCode.tsx:34
+#: src/components/ConfirmVerificationEmail.tsx:28
 msgid "You’ve been verified! Please wait."
 msgstr "You’ve been verified! Please wait."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,6 +18,7 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 64\n"
 
+#: src/components/ConfirmVerificationEmail.tsx:40
 #: src/components/SendVerificationCode.tsx:46
 #: src/components/SendVerificationEmail.tsx:31
 msgid "Error: {0}"
@@ -48,6 +49,7 @@ msgstr "Por favor completa el captcha para proceder."
 msgid "Please provide a valid phone number."
 msgstr "Por favor provee un número de teléfono válido."
 
+#: src/components/ConfirmVerificationEmail.tsx:35
 #: src/components/SendVerificationCode.tsx:41
 #: src/components/SendVerificationEmail.tsx:26
 msgid "Please wait…"
@@ -83,6 +85,7 @@ msgid "We’ve sent you a verification code:"
 msgstr "Te hemos enviado un código de verificación:"
 
 #: src/components/ConfirmVerificationCode.tsx:34
+#: src/components/ConfirmVerificationEmail.tsx:28
 msgid "You’ve been verified! Please wait."
 msgstr "¡Has sido verificado! Por favor espera."
 

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -12,6 +12,9 @@ export interface AppConfig {
   email?: string;
   dynamicLinkSettings?: DynamicLinkSettings;
 
+  // required for 'confirm auth with email'
+  signInLink?: string;
+
   recaptchaVerifier: firebase.auth.RecaptchaVerifier;
   language: string;
 }

--- a/src/types.d/Page.ts
+++ b/src/types.d/Page.ts
@@ -1,5 +1,6 @@
 export enum Page {
   confirmVerificationCode = "confirmVerificationCode",
+  confirmVerificationEmail = "confirmVerificationEmail",
   landing = "landing",
   sendVerificationCode = "sendVerificationCode",
   sendVerificationEmail = "sendVerificationEmail",

--- a/src/types.d/State.ts
+++ b/src/types.d/State.ts
@@ -9,6 +9,8 @@ export interface State {
   email?: string;
   dynamicLinkSettings?: DynamicLinkSettings;
 
+  signInLink?: string;
+
   currentPage: Page;
   appDidLoad: boolean;
   statuses: { [key: string]: Status };


### PR DESCRIPTION
Steps to auth with email:
- call `main` with an `email` and `dynamicLinkSettings` 
- a sign-in link will be sent to that email
- refresh this app and call `main` again, but this time with `email` and `signInLink`
- you will be singed in / the app will return an idToken