### PR TITLE
Re-format dynamicLinkSettings to match Firebase docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Run the following script in your browser console:
 ```js
 main({
   email: "jordyn@example.com",
-  // Client needs to pass in dynamicLinkSettings, they change depending on
-  // the env and are used by Firebase to generate a sign-in link
+  // These settings are used by Firebase to generate a dynamic sign-in link
   dynamicLinkSettings: {
-    domain: "pasapesos.page.link", // dynamic link domain
-    path: "auth-email", // dynamic link path
-    referrerId: "io.example.app", // app the dynamic link will send you to
+    dynamicLinkDomain: "example.page.link",
+    url: "https://example.page.link/auth-email",
+    android: { installApp: true, packageName: "io.example.app" },
+    iOS: { bundleId: "io.example.app" },
+    handleCodeInApp: true,
   },
 });
 ```

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -23,18 +23,9 @@ export async function sendVerificationEmail({
   const setStatus = buildStatus(SEND_VERIFICATION_EMAIL, dispatch);
   setStatus(StatusType.loading);
 
-  const { referrerId, domain, path } = dynamicLinkSettings;
-  const dynamicLinkConfig = {
-    android: { installApp: true, packageName: referrerId },
-    domain: `${domain}`,
-    handleCodeInApp: true,
-    iOS: { bundleId: referrerId },
-    url: `https://${domain}/${path}`,
-  };
-
   firebase
     .auth()
-    .sendSignInLinkToEmail(email, dynamicLinkConfig)
+    .sendSignInLinkToEmail(email, dynamicLinkSettings)
     .then(() => {
       dispatch(action());
       setStatus(StatusType.success);

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -1,7 +1,9 @@
 export interface DynamicLinkSettings {
-  referrerId: string;
-  domain: string;
-  path: string;
+  dynamicLinkDomain: string;
+  url: string;
+  android: { installApp: boolean; packageName: string };
+  iOS: { bundleId: string };
+  handleCodeInApp: true;
 }
 
 export interface AppConfig {


### PR DESCRIPTION
Initially, I was trying to simplify the amount of params to pass in, but as I've been using it, I've decided it is more clear to match the docs.

https://firebase.google.com/docs/auth/web/passing-state-in-email-actions#passing_statecontinue_url_in_email_actions