### PR TITLE
Switch build image to ubuntu 20.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 LABEL ?= $(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # If TAG is not provided set default value
 TAG ?= stellar/recoverysigner-firebase-auth:$(LABEL)
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
 
 docker-build:
-	$(SUDO) docker build -f docker/Dockerfile -t $(TAG) .
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	-f docker/Dockerfile -t $(TAG) .
 
 docker-push:
 	$(SUDO) docker push $(TAG)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:16.04 as build
+FROM ubuntu:20.04 as build
 
-RUN apt-get update && apt-get install -y curl git apt-transport-https && \
-    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb https://deb.nodesource.com/node_10.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --no-install-recommends -y gpg curl git ca-certificates apt-transport-https && \
+    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key|gpg --dearmor >/etc/apt/trusted.gpg.d/nodesource.gpg && \
+    echo "deb https://deb.nodesource.com/node_10.x focal main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |gpg --dearmor >/etc/apt/trusted.gpg.d/yarnpkg.gpg && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y nodejs yarn
 


### PR DESCRIPTION
* switch to ubuntu 20.04 base image
* move away from deprecated "apt-key add"
* use --no-install-recommends to reduce number of packages installed
* add --pull to the Makefile to ensure we always use latest images
* add image.created label