### PR TITLE
Disable unneed Sentry tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@lingui/macro": "^2.9.1",
     "@lingui/react": "^2.9.1",
     "@sentry/browser": "^6.16.1",
-    "@sentry/tracing": "^6.16.1",
     "@stellar/eslint-config": "^1.0.3",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { I18nProvider } from "@lingui/react";
 import * as Sentry from "@sentry/browser";
-import { Integrations } from "@sentry/tracing";
 
 import "./index.css";
 import { i18n } from "config/i18n";
@@ -27,12 +26,6 @@ import { AppConfig } from "types.d/AppConfig";
   if (appEnv.SENTRY_DSN) {
     Sentry.init({
       dsn: appEnv.SENTRY_DSN,
-      integrations: [new Integrations.BrowserTracing()],
-
-      // Set tracesSampleRate to 1.0 to capture 100%
-      // of transactions for performance monitoring.
-      // We recommend adjusting this value in production
-      tracesSampleRate: 1.0,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,17 +1908,6 @@
     "@sentry/types" "6.16.1"
     tslib "^1.9.3"
 
-"@sentry/tracing@^6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.16.1.tgz#32fba3e07748e9a955055afd559a65996acb7d71"
-  integrity sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==
-  dependencies:
-    "@sentry/hub" "6.16.1"
-    "@sentry/minimal" "6.16.1"
-    "@sentry/types" "6.16.1"
-    "@sentry/utils" "6.16.1"
-    tslib "^1.9.3"
-
 "@sentry/types@6.16.1":
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.16.1.tgz#4917607115b30315757c2cf84f80bac5100b8ac0"


### PR DESCRIPTION
Sentry's integration guide automatically includes performance tracing, but we don't need it.