### PR TITLE
Enable "es-AR" and "ru" languages

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -2,12 +2,15 @@ import { Catalog, setupI18n } from "@lingui/core";
 
 import en from "locales/en/messages";
 import es from "locales/es/messages";
+import esAR from "locales/es-AR/messages";
 import uk from "locales/uk/messages";
 
-const catalogs: { [key: string]: Catalog } = {
+export const catalogs: { [key: string]: Catalog } = {
   en,
   es,
+  "es-AR": esAR,
   uk,
+  ru: uk,
 };
 
 export const i18n = setupI18n({

--- a/src/helpers/determineLanguage.ts
+++ b/src/helpers/determineLanguage.ts
@@ -1,0 +1,22 @@
+import { catalogs } from "config/i18n";
+
+// input could be in both "en" and "en-US" formats
+export function determineLanguage(input: string): string {
+  let language;
+
+  const [languageFromInput, countryFromInput] = input.split("-");
+
+  if (input in catalogs) {
+    language = input;
+  } else if (languageFromInput in catalogs) {
+    language = languageFromInput;
+  } else if (countryFromInput && countryFromInput === "AR") {
+    language = "es-AR";
+  } else if (countryFromInput && ["UA", "RU"].includes(countryFromInput)) {
+    language = "uk";
+  } else {
+    language = "en";
+  }
+
+  return language;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { i18n } from "config/i18n";
 import { initializeFirebase, auth } from "config/firebase";
 import { App } from "components/App";
 import { store } from "ducks/store";
+import { determineLanguage } from "helpers/determineLanguage";
 import { AppConfig } from "types.d/AppConfig";
 
 (window as any).Sentry = Sentry;
@@ -23,7 +24,7 @@ if ((window as any).APP_ENV) {
   (window as any).wasInitted = true;
 
   const appEnv = (window as any).APP_ENV;
-  const language = config.language || "en";
+  const language = determineLanguage(config.language || "en");
 
   initializeFirebase({
     apiKey: appEnv.FIREBASE_WEB_API_KEY,

--- a/src/locales/es-AR/messages.po
+++ b/src/locales/es-AR/messages.po
@@ -5,16 +5,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: uk\n"
+"Language: es_AR\n"
 "Project-Id-Version: vibrant-app\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2022-10-20 12:43\n"
+"PO-Revision-Date: 2022-10-20 12:42\n"
 "Last-Translator: \n"
-"Language-Team: Ukrainian\n"
-"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
+"Language-Team: Spanish, Argentina\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Crowdin-Project: vibrant-app\n"
 "X-Crowdin-Project-ID: 409066\n"
-"X-Crowdin-Language: uk\n"
+"X-Crowdin-Language: es-AR\n"
 "X-Crowdin-File: /recoverysigner-firebase-auth/messages.po\n"
 "X-Crowdin-File-ID: 64\n"
 
@@ -22,49 +22,49 @@ msgstr ""
 #: src/components/SendVerificationCode.tsx:50
 #: src/components/SendVerificationEmail.tsx:35
 msgid "Error: {0}"
-msgstr "Помилка: {0}"
+msgstr "Error: {0}"
 
 #: src/components/SentVerificationEmail.tsx:15
 msgid "If the below email address is associated with an account, you will receive a verification email."
-msgstr "Якщо вказана нижче адреса електронної пошти пов’язана з обліковим записом, ви отримаєте електронний лист із підтвердженням."
+msgstr "Si la dirección de email, aquí debajo, está asociada con una cuenta, vas a recibir un email de verificación."
 
 #: src/components/SentVerificationEmail.tsx:22
 msgid "Please check your email on your device and click the verification link in the email message to proceed."
-msgstr "Для продовження, перевірте свою поштову скриньку на вашому пристрої та натисніть на посилання для підтвердження в електронному листі, який ми вам надіслали."
+msgstr "Por favor, abrí en tu celular el correo que te enviamos y hacé clic en el link de verificación para proceder."
 
 #: src/config/i18n.ts:15
 msgid "Please update Android WebView to start the session."
-msgstr "Будь ласка, оновіть Android WebView, щоб розпочати сесію."
+msgstr "Por favor actualizá tu Android WebView para comenzar sesión."
 
 #: src/config/i18n.ts:16
 msgid "Please update Google Chrome to start the session."
-msgstr "Будь ласка, оновіть Google Chrome, щоб розпочати сесію."
+msgstr "Por favor actualizá Google Chrome para comenzar la sesión."
 
 #: src/components/ConfirmVerificationEmail.tsx:35
 #: src/components/SendVerificationCode.tsx:45
 #: src/components/SendVerificationEmail.tsx:30
 msgid "Please wait…"
-msgstr "Зачекайте…"
+msgstr "Por favor esperá…"
 
 #: src/components/ConfirmVerificationCode.tsx:54
 #: src/components/SentVerificationEmail.tsx:32
 msgid "Resend"
-msgstr "Надіслати повторно"
+msgstr "Reenviar"
 
 #: src/components/SendVerificationCode.tsx:56
 msgid "Send verification code"
-msgstr "Надіслати код підтвердження"
+msgstr "Enviar código de verificación"
 
 #: src/components/ConfirmVerificationCode.tsx:41
 msgid "We’ve sent you a verification code:"
-msgstr "Ми надіслали вам код підтвердження:"
+msgstr "Te hemos enviado un código de verificación:"
 
 #: src/config/i18n.ts:17
 msgid "Your device’s browser is not compatible. Please update your browser and Vibrant to the latest version."
-msgstr "На вашому пристрої встановлена застаріла версія браузера. Будь ласка, оновіть ваш браузер і додаток Vibrant до останньої версії."
+msgstr "El navegador en tu dispositivo no es compatible. Por favor actualizá el navegador y la app de Vibrant a sus últimas versiones."
 
 #: src/components/ConfirmVerificationCode.tsx:34
 #: src/components/ConfirmVerificationEmail.tsx:28
 msgid "You’ve been verified! Please wait."
-msgstr "Ви пройшли перевірку. Зачекайте."
+msgstr "¡Has sido verificado! Por favor espera."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-07-20 15:50-0700\n"
+"POT-Creation-Date: 2020-07-20 15:25-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Language: es\n"
 "Project-Id-Version: vibrant-app\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2021-04-27 17:12\n"
+"PO-Revision-Date: 2022-10-20 12:42\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -30,15 +30,15 @@ msgstr "Si la dirección de email, aquí debajo, está asociada con una cuenta, 
 
 #: src/components/SentVerificationEmail.tsx:22
 msgid "Please check your email on your device and click the verification link in the email message to proceed."
-msgstr "Por favor, abrí en tu celular el correo que te enviamos y seguí el link de verificación para proceder."
+msgstr "Por favor, abre en tu celular el correo que te enviamos y haz click en el link de verificación para proceder."
 
 #: src/config/i18n.ts:15
 msgid "Please update Android WebView to start the session."
-msgstr "Actualice Android WebView para iniciar sesión."
+msgstr "Por favor actualiza tu Android WebView para comenzar sesión."
 
 #: src/config/i18n.ts:16
 msgid "Please update Google Chrome to start the session."
-msgstr "Actualice Google Chrome para iniciar sesión."
+msgstr "Por favor acutaliza Google Chrome antes de comenzar la sesión."
 
 #: src/components/ConfirmVerificationEmail.tsx:35
 #: src/components/SendVerificationCode.tsx:45
@@ -61,9 +61,10 @@ msgstr "Te hemos enviado un código de verificación:"
 
 #: src/config/i18n.ts:17
 msgid "Your device’s browser is not compatible. Please update your browser and Vibrant to the latest version."
-msgstr "El navegador de tu dispositivo no es compatible. Actualizá tu navegador o bajate la última versión de Vibrant."
+msgstr "El navegador en tu dispositivo no es compatible. Por favor actualiza tu navegador y la app de Vibrant a sus últimas versiones."
 
 #: src/components/ConfirmVerificationCode.tsx:34
 #: src/components/ConfirmVerificationEmail.tsx:28
 msgid "You’ve been verified! Please wait."
 msgstr "¡Has sido verificado! Por favor espera."
+

--- a/src/types.d/AppConfig.ts
+++ b/src/types.d/AppConfig.ts
@@ -20,5 +20,7 @@ export interface AppConfig {
   signInLink?: string;
 
   recaptchaVerifier: RecaptchaVerifier;
+
+  // accepts both "en" and "en-US" formats
   language: string;
 }


### PR DESCRIPTION
### Included in this PR:
- Enable taking `language` param in the **locale** format
  - e.g. the wallet could send it as "en", "en-US", "es", "es-AR", etc.
- Add "ru" catalog which should alias the "uk" catalog
- Add "es-AR" catalog
- Update a few "es" and "uk" translations

This PR has no breaking changes as the `AppConfig` interface remains the same