### PR TITLE
Update ubuntu to 22.04 from 20.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:22.04 as build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y gpg curl git ca-certificates apt-transport-https && \


### PR DESCRIPTION
### What:

Update Ubuntu to 22.04 from 20.04.

### Why:


We are upgrading docker base image to 22.04 in SDF infrastructure.