### PR TITLE
Change port for recovery signer from 80 to 8080

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80;
+    listen       8080;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
### What:


Change port for recovery signer from 80 to 8080



### Why:


Port 80 is not supported by EKS.


### Issue:

https://github.com/stellar/ops/issues/3216