### PR TITLE
Simplify SendVerificationCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+package-lock.json
 /.pnp
 .pnp.js
 

--- a/src/components/SendVerificationCode.tsx
+++ b/src/components/SendVerificationCode.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Trans } from "@lingui/react/macro";
-import { debounce } from "lodash";
+import { Trans } from "@lingui/macro";
 
 import { SEND_VERIFICATION_CODE } from "ducks/firebase";
 import { setPage } from "ducks/page";
@@ -11,34 +10,16 @@ import { Page } from "types/Page";
 import { type State } from "types/State";
 import { useAppDispatch } from "hooks/useAppDispatch";
 
-const DELAY = 3000;
-
 export function SendVerificationCode() {
   const appEnv = (window as any).APP_ENV;
 
   const dispatch = useAppDispatch();
   const sendCodeStatus = useStatus(SEND_VERIFICATION_CODE);
-  const [isLoading, setIsLoading] = useState(true);
   const phoneNumber = useSelector((state: State) => state.phoneNumber ?? "");
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const sendVerificationCodeDebounce = useCallback(
-    debounce(() => {
-      if (phoneNumber) {
-        sendVerificationCode({ phoneNumber, dispatch });
-      }
-    }, 1000),
-    [phoneNumber, dispatch],
-  );
-
   const handleSendVerification = () => {
-    sendVerificationCodeDebounce();
+    sendVerificationCode({ phoneNumber, dispatch });
   };
-
-  useEffect(() => {
-    handleSendVerification();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     if (sendCodeStatus.isSuccess) {
@@ -46,44 +27,28 @@ export function SendVerificationCode() {
     }
   }, [sendCodeStatus.isSuccess, dispatch]);
 
-  // We automatically trigger the recaptcha verification. To avoid flashing the
-  // "Send verification code" button, we display the button when DELAY has
-  // passed.
-  useEffect(() => {
-    const tid = setTimeout(() => {
-      setIsLoading(false);
-    }, DELAY);
-
-    return () => clearTimeout(tid);
-  }, []);
-
   return (
     <div className="panel">
-      {isLoading && (
-        <div className="text-center">
-          <p>
+      <button
+        className="button"
+        style={{ backgroundColor: appEnv.BUTTON_COLOR }}
+        onClick={handleSendVerification}
+        disabled={
+          !phoneNumber || sendCodeStatus.isLoading || sendCodeStatus.isSuccess
+        }
+      >
+        <span>
+          {sendCodeStatus.isLoading || sendCodeStatus.isSuccess ? (
             <Trans>Please wait…</Trans>
-          </p>
-        </div>
-      )}
+          ) : (
+            <Trans>Send verification code</Trans>
+          )}
+        </span>
+      </button>
 
       {sendCodeStatus.error && (
         <p>
           <Trans>Error: {sendCodeStatus.error.message}</Trans>
-        </p>
-      )}
-
-      {!isLoading && !sendCodeStatus.error && (
-        <p className="text-center">
-          <button
-            className="button"
-            style={{ backgroundColor: appEnv.BUTTON_COLOR }}
-            onClick={handleSendVerification}
-          >
-            <span>
-              <Trans>Send verification code</Trans>
-            </span>
-          </button>
         </p>
       )}
     </div>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -66,7 +66,7 @@ msgstr "Your device's browser is not compatible. Please update your browser and 
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Error: {0}"
@@ -102,7 +102,7 @@ msgstr "Please provide a valid phone number."
 #~ msgstr "Please update Google Chrome to start the session."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Please wait…"
@@ -112,7 +112,7 @@ msgstr "Please wait…"
 msgid "Resend"
 msgstr "Resend"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Send verification code"
 

--- a/src/locales/es-AR/messages.po
+++ b/src/locales/es-AR/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Error: {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Por favor actualizá Google Chrome para comenzar la sesión."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Por favor esperá…"
@@ -115,7 +115,7 @@ msgstr "Por favor esperá…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Enviar código de verificación"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Error: {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Por favor acutaliza Google Chrome antes de comenzar la sesión."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Por favor esperá…"
@@ -115,7 +115,7 @@ msgstr "Por favor esperá…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Enviar código de verificación"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Erreur : {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Veuillez mettre à jour Google Chrome pour démarrer la session."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Veuillez patienter…"
@@ -115,7 +115,7 @@ msgstr "Veuillez patienter…"
 msgid "Resend"
 msgstr "Renvoyer"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Envoyer un code de vérification"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Erro: {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Atualize o Google Chrome para iniciar a sessão."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Aguarde…"
@@ -115,7 +115,7 @@ msgstr "Aguarde…"
 msgid "Resend"
 msgstr "Reenviar"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Enviar código de verificação"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Ошибка: {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Обновите Google Chrome, чтобы начать сессию."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Подождите…"
@@ -115,7 +115,7 @@ msgstr "Подождите…"
 msgid "Resend"
 msgstr "Отправить еще раз"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Отправить код подтверждения"
 

--- a/src/locales/uk/messages.po
+++ b/src/locales/uk/messages.po
@@ -69,7 +69,7 @@ msgstr ""
 #. placeholder {0}: sendCodeStatus.error.message
 #. placeholder {0}: sendEmailStatus.error.message
 #: src/components/ConfirmVerificationEmail.tsx:57
-#: src/components/SendVerificationCode.tsx:72
+#: src/components/SendVerificationCode.tsx:51
 #: src/components/SendVerificationEmail.tsx:51
 msgid "Error: {0}"
 msgstr "Помилка: {0}"
@@ -105,7 +105,7 @@ msgstr ""
 #~ msgstr "Будь ласка, оновіть Google Chrome, щоб розпочати сесію."
 
 #: src/components/ConfirmVerificationEmail.tsx:49
-#: src/components/SendVerificationCode.tsx:65
+#: src/components/SendVerificationCode.tsx:42
 #: src/components/SendVerificationEmail.tsx:43
 msgid "Please wait…"
 msgstr "Зачекайте…"
@@ -115,7 +115,7 @@ msgstr "Зачекайте…"
 msgid "Resend"
 msgstr "Надіслати повторно"
 
-#: src/components/SendVerificationCode.tsx:84
+#: src/components/SendVerificationCode.tsx:44
 msgid "Send verification code"
 msgstr "Надіслати код підтвердження"
 


### PR DESCRIPTION
## Changes

**SendVerificationCode**:

- Removed auto-send SMS (the user must press the button to request it)
- Button is disabled during loading/success, so the user can't re-trigger the SMS while a request is in progress
- Button label switches to "Please wait…" during loading/success, so the user can understand what's happening

## Attempting to solves these issues

1. Some users get stuck in a captcha loop: complete captcha → modal dismisses → tap "Send verification code" → another captcha opens. The page auto-triggered `sendVerificationCode()` on mount and didn't disable the button while loading, so users could tap again mid-request and trigger a new reCAPTCHA.

2. Users leave the app to check their SMS and then return to find another SMS sent. Returning could remount the component and re-run the auto-trigger, sending a second code.

