### PR TITLE
[ENG-5340] ci: replace AWS static credentials with GitHub OIDC

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-publish:
     name: Build Image
@@ -14,11 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr-public


### PR DESCRIPTION
### What

Replaces AWS static credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) in the ECR build-and-push workflow with GitHub OIDC. The `aws-actions/configure-aws-credentials` step now assumes an IAM role via `role-to-assume` and is pinned to a commit SHA (v6.2.3). Adds the required `permissions` block (`id-token: write`, `contents: read`) and moves the role ARN and region to GitHub variables (`AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`).

### Why

Removes long-lived AWS access keys from GitHub secrets in favor of short-lived credentials obtained through OIDC federation — improving security posture and eliminating manual key rotation.

### Known limitations

Requires the following GitHub variables to be configured in the repository (or org): `AWS_DEPLOY_ROLE_ARN` and `AWS_REGION`. The target IAM role's trust policy must allow the GitHub OIDC provider for this repository/branch before the workflow can assume it.

### Ticket

[ENG-5340](https://linear.app/vesseo/issue/ENG-5340)